### PR TITLE
add creator field to request and response for createDraft

### DIFF
--- a/MountRushmore/CreateDraft/CreateRepository.swift
+++ b/MountRushmore/CreateDraft/CreateRepository.swift
@@ -3,6 +3,7 @@ import Foundation
 struct CreateDraftRequest: Encodable {
     let name: String
     let topic: String
+    let creator: Creator
 }
 
 struct CreateRepository {
@@ -13,11 +14,11 @@ struct CreateRepository {
         self.api = api
     }
     
-    func createDraft(draftName: String, topic: String) async throws -> Draft {
+    func createDraft(draftName: String, topic: String, creator: Creator) async throws -> Draft {
         return try await api.makeRequest(
             httpMethod: .POST,
             path: "https://us-central1-mount-rushmore-cde9b.cloudfunctions.net/createDraft",
-            body: CreateDraftRequest(name: draftName, topic: topic)
+            body: CreateDraftRequest(name: draftName, topic: topic, creator: creator)
         )
     }
 } 

--- a/MountRushmore/CreateDraft/CreateViewModel.swift
+++ b/MountRushmore/CreateDraft/CreateViewModel.swift
@@ -12,7 +12,7 @@ class CreateViewModel: ObservableObject {
     private let viewEventSubject = PassthroughSubject<CreateViewEvent, Never>()
     private var cancellables = Set<AnyCancellable>()
 
-    init(interactor: CreateInteractor = CreateInteractor()) {
+    init(interactor: CreateInteractor) {
         self.interactor = interactor
         
         viewEventSubject

--- a/MountRushmore/CreateDraft/Draft.swift
+++ b/MountRushmore/CreateDraft/Draft.swift
@@ -10,10 +10,16 @@ struct Draft: Decodable, Identifiable {
     let participants: [Participant]
     let picks: [Pick]
     let draftId: String
+    let creator: Creator
+}
+
+struct Creator: Codable, Hashable {
+    let name: String
+    let userId: String
 }
 
 struct Participant: Decodable, Hashable {
-    let id: String
+    let userId: String
     let name: String
 }
 struct Pick: Decodable, Hashable {} 

--- a/MountRushmore/DraftDetails/DraftDetailsInteractor.swift
+++ b/MountRushmore/DraftDetails/DraftDetailsInteractor.swift
@@ -69,7 +69,7 @@ struct DraftDetailsInteractor {
                     return DraftDetailsDomainState(loadingState: loadedState, hasJoinedDraft: false)
                 }
                 
-                let hasJoined = draft.participants.contains { $0.id == userId }
+                let hasJoined = draft.participants.contains { $0.userId == userId }
                 
                 return DraftDetailsDomainState(loadingState: loadedState, hasJoinedDraft: hasJoined)
             } catch {

--- a/MountRushmore/DraftDetails/DraftDetailsInteractor.swift
+++ b/MountRushmore/DraftDetails/DraftDetailsInteractor.swift
@@ -9,6 +9,7 @@ enum DraftDetailsDomainAction {
 /// A struct representing the state of the application's domain.
 struct DraftDetailsDomainState {
     var loadingState: LoadingState = .idle
+    var hasJoinedDraft: Bool = false
 
     enum LoadingState {
         case idle
@@ -22,9 +23,14 @@ struct DraftDetailsDomainState {
 struct DraftDetailsInteractor {
     
     let repository: DraftDetailsRepository
+    let authState: AuthState
     
-    init(repository: DraftDetailsRepository = DraftDetailsRepository()) {
+    init(
+        repository: DraftDetailsRepository = DraftDetailsRepository(),
+        authState: AuthState = AuthState()
+    ) {
         self.repository = repository
+        self.authState = authState
     }
     
     /// This is the main Combine-based interaction point for the interactor.
@@ -59,7 +65,13 @@ struct DraftDetailsInteractor {
             do {
                 let draft = try await repository.getDraftDetails(draftId: draftId)
                 let loadedState = DraftDetailsDomainState.LoadingState.loaded(draft: draft)
-                return DraftDetailsDomainState(loadingState: loadedState)
+                guard let userId = authState.user?.uid else {
+                    return DraftDetailsDomainState(loadingState: loadedState, hasJoinedDraft: false)
+                }
+                
+                let hasJoined = draft.participants.contains { $0.id == userId }
+                
+                return DraftDetailsDomainState(loadingState: loadedState, hasJoinedDraft: hasJoined)
             } catch {
                 print("Failed to fetch draft details: \(error)")
                 return DraftDetailsDomainState(loadingState: .idle)

--- a/MountRushmore/DraftDetails/DraftDetailsScreen.swift
+++ b/MountRushmore/DraftDetails/DraftDetailsScreen.swift
@@ -2,8 +2,11 @@ import SwiftUI
 
 struct DraftDetailsScreen: View {
     let draftId: String
+    @EnvironmentObject var authState: AuthState
     
     var body: some View {
-        DraftDetailsView(draftId: draftId)
+        let interactor = DraftDetailsInteractor(authState: authState)
+        let viewModel = DraftDetailsViewModel(interactor: interactor)
+        DraftDetailsView(viewModel: viewModel, draftId: draftId)
     }
 } 

--- a/MountRushmore/DraftDetails/DraftDetailsView.swift
+++ b/MountRushmore/DraftDetails/DraftDetailsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 // MARK: - View
 
 struct DraftDetailsView: View {
-    @StateObject private var viewModel = DraftDetailsViewModel()
+    @ObservedObject var viewModel: DraftDetailsViewModel
     @State private var justCopied: Bool = false
     let draftId: String
 
@@ -68,17 +68,31 @@ struct DraftDetailsView: View {
 
             Spacer()
 
-            // START Button
-            Button(action: {
-                // Action for the START button
-            }) {
-                Text("draftDetails.startButton")
-                    .fontWeight(.bold)
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
+            // CTA Button
+            if viewModel.state.hasJoinedDraft {
+                Button(action: {
+                    // Action for the START button
+                }) {
+                    Text("draftDetails.startButton")
+                        .fontWeight(.bold)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+            } else {
+                Button(action: {
+                    // Action for the JOIN button
+                }) {
+                    Text("draftDetails.joinButton")
+                        .fontWeight(.bold)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.orange.opacity(0.8))
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
             }
         }
     }
@@ -100,6 +114,9 @@ struct DraftDetailsView: View {
 
 #Preview {
     NavigationView {
-        DraftDetailsView(draftId: "123")
+        let authState = AuthState()
+        let interactor = DraftDetailsInteractor(authState: authState)
+        let viewModel = DraftDetailsViewModel(interactor: interactor)
+        DraftDetailsView(viewModel: viewModel, draftId: "123")
     }
 } 

--- a/MountRushmore/DraftDetails/DraftDetailsViewModel.swift
+++ b/MountRushmore/DraftDetails/DraftDetailsViewModel.swift
@@ -13,7 +13,7 @@ final class DraftDetailsViewModel: ObservableObject {
 
     init(
         initialState: DraftDetailsViewState = .initial,
-        interactor: DraftDetailsInteractor = DraftDetailsInteractor()
+        interactor: DraftDetailsInteractor
     ) {
         self.state = initialState
         self.interactor = interactor
@@ -71,7 +71,8 @@ final class DraftDetailsViewModel: ObservableObject {
                 topic: draft.topic,
                 link: "https://mountrushmore.app/draft/\(draft.id)",
                 participants: draft.participants.map { $0.name },
-                isLoading: false
+                isLoading: false,
+                hasJoinedDraft: domainState.hasJoinedDraft
             )
         }
     }
@@ -90,6 +91,7 @@ struct DraftDetailsViewState {
     var participants: [String] = []
     var ctaText: String = ""
     var isLoading: Bool = true
+    var hasJoinedDraft: Bool = false
     
     static var initial: DraftDetailsViewState {
         DraftDetailsViewState()

--- a/MountRushmore/Localizable.strings
+++ b/MountRushmore/Localizable.strings
@@ -31,3 +31,4 @@
 "draftDetails.copiedBanner" = "Copied!";
 "draftDetails.participantsHeader" = "PARTICIPANTS";
 "draftDetails.startButton" = "START"; 
+"draftDetails.joinButton" = "JOIN"; 

--- a/MountRushmore/Start/StartScreen.swift
+++ b/MountRushmore/Start/StartScreen.swift
@@ -30,11 +30,12 @@ struct StartScreen: View {
                 switch route {
                 case .createDraft:
                     CreateDraftScreen(
-                        viewModel: CreateViewModel(interactor: CreateInteractor()),
+                        viewModel: CreateViewModel(interactor: CreateInteractor(authState: authState)),
                         path: $path
                     )
                 case .draftDetails(let draftId):
                     DraftDetailsScreen(draftId: draftId)
+                        .environmentObject(authState)
                 }
             }
             .sheet(isPresented: $showingLoginScreen) {


### PR DESCRIPTION
- added the creator field to the createDraft request, and parse it in its response as well
- also added the ability to distinguish between someone who has joined and who hasn't in the draft details screen 